### PR TITLE
Updated lwc to reflect correct end date

### DIFF
--- a/force-app/main/default/lwc/activeContracts/activeContracts.html
+++ b/force-app/main/default/lwc/activeContracts/activeContracts.html
@@ -116,7 +116,7 @@
                             </td>
                             <td data-label={label.endDate}>
                                 <div class="active-contracts-table-header">{label.endDate}</div>
-                                <div class="slds-truncate" title={contract.terminationDate}>{contract.terminationDate}</div>
+                                <div class="slds-truncate" title={contract.endDate}>{contract.endDate}</div>
                             </td>
                             <td data-label={label.contractTerm}>
                                 <div class="active-contracts-table-header">{label.contractTerm}</div>


### PR DESCRIPTION
https://github.com/rjhalvorson/cancelAndReplace/issues/1#issue-839656024

# Details
The lightning component always shows a contract end date of Today. This is due to an issue where the wrong field is mapped to the component. This bug has been resolved.

## Types of changes
<!--- What types of changes does the code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
